### PR TITLE
feat(record-entry): changed placement for newly added records

### DIFF
--- a/scripts/index.js
+++ b/scripts/index.js
@@ -62,7 +62,6 @@ function getModifierState(event) {
 
 function addRow(event) {
   document.getElementById("key-id").innerHTML = `<mark>${event.key}</mark>`;
-  const curIndx = document.getElementById("event-table-body").rows.length;
   const row = document.getElementById("event-table-body").insertRow(0);
   const data = [
     event.type,

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -63,7 +63,7 @@ function getModifierState(event) {
 function addRow(event) {
   document.getElementById("key-id").innerHTML = `<mark>${event.key}</mark>`;
   const curIndx = document.getElementById("event-table-body").rows.length;
-  const row = document.getElementById("event-table-body").insertRow(curIndx);
+  const row = document.getElementById("event-table-body").insertRow(0);
   const data = [
     event.type,
     event.which,
@@ -81,7 +81,6 @@ function addRow(event) {
     const cell = row.insertCell(counter);
     cell.innerHTML = `<span class='v-${data[counter]}'>${data[counter]}</span>`;
   }
-  window.scrollTo(0, document.body.scrollHeight);
 }
 
 const clearAll = (event) => {


### PR DESCRIPTION
### Related Issue or bug
Difficulty in viewing new information added to tables

Fixes: https://github.com/atapas/js-keyevents-demo/issues/12

### Proposed Changes
- Defined structure to show key events for user's input in recent first manner
- Added handling for new records to be entered at top of list
- Removed scroll behavior to bottom of document