### PR TITLE
correct typo on function name - "function closeDialig"

### DIFF
--- a/scripts/index.js
+++ b/scripts/index.js
@@ -146,7 +146,7 @@ document
     exportJSONToCSV(keyCodeList);
 });
 
-function closeDialig() {
+function closeDialog() {
   document.getElementById('keyCodeDialog').close();
 }
 


### PR DESCRIPTION
I didn't find any calls to this function in index.js, only updated the function name.